### PR TITLE
Clarifications regarding backwards compatibility

### DIFF
--- a/draft-tschofenig-rats-psa-token.md
+++ b/draft-tschofenig-rats-psa-token.md
@@ -580,9 +580,8 @@ The new profile introduces three further changes:
 * the "Certification Reference" syntax changed from EAN-13 to EAN-13+5 (see
   {{sec-certification-reference}}).
 
-Unless compatibility with existing infrastructure is a concern, emitters (e.g.,
-devices that implement the PSA Attestation API) MUST produce tokens with
-the claim keys specified in this document.
+Unless compatibility with existing infrastructure is a concern, Attesters
+MUST produce tokens with the claim keys specified in this document.
 
 To simplify the transition to the token format described in this
 document it is RECOMMENDED that receivers (e.g., PSA Attestation Verifiers)

--- a/draft-tschofenig-rats-psa-token.md
+++ b/draft-tschofenig-rats-psa-token.md
@@ -580,7 +580,6 @@ The new profile introduces three further changes:
 * the "Certification Reference" syntax changed from EAN-13 to EAN-13+5 (see
   {{sec-certification-reference}}).
 
-Attesters MUST produce tokens with the new claim keys specified in this document.
 
 To simplify the transition to the token format described in this
 document it is RECOMMENDED that receivers (e.g., PSA Attestation Verifiers)

--- a/draft-tschofenig-rats-psa-token.md
+++ b/draft-tschofenig-rats-psa-token.md
@@ -570,7 +570,7 @@ keys.
 | Certification Reference | -75005 | 2398 |
 | Software Components | -75006 | 2399 |
 | Verification Service Indicator | -75010 | 2400 |
-{: #tab-claim-map title="Claim key mappings"}
+{: #tab-claim-map title="Claim Key Mappings"}
 
 The new profile introduces three further changes:
 
@@ -580,8 +580,7 @@ The new profile introduces three further changes:
 * the "Certification Reference" syntax changed from EAN-13 to EAN-13+5 (see
   {{sec-certification-reference}}).
 
-Unless compatibility with existing infrastructure is a concern, Attesters
-MUST produce tokens with the claim keys specified in this document.
+Attesters MUST produce tokens with the new claim keys specified in this document.
 
 To simplify the transition to the token format described in this
 document it is RECOMMENDED that receivers (e.g., PSA Attestation Verifiers)

--- a/draft-tschofenig-rats-psa-token.md
+++ b/draft-tschofenig-rats-psa-token.md
@@ -581,7 +581,7 @@ The new profile introduces three further changes:
   {{sec-certification-reference}}).
 
 Unless compatibility with existing infrastructure is a concern, emitters (e.g.,
-devices that implement the PSA Attestation API) SHOULD produce tokens with
+devices that implement the PSA Attestation API) MUST produce tokens with
 the claim keys specified in this document.
 
 To simplify the transition to the token format described in this

--- a/draft-tschofenig-rats-psa-token.md
+++ b/draft-tschofenig-rats-psa-token.md
@@ -582,7 +582,7 @@ The new profile introduces three further changes:
 
 
 To simplify the transition to the token format described in this
-document it is RECOMMENDED that receivers (e.g., PSA Attestation Verifiers)
+document it is RECOMMENDED that Verifiers
 accept tokens encoded according to the old profile (`PSA_IOT_PROFILE_1`) as well as
 to the new profile (`tag:psacertified.org,2023:psa#tfm`), at least for the time needed to
 their clients to upgrade.


### PR DESCRIPTION
Why use a SHOULD here? This will make life more difficult in the long run