### PR TITLE
guidelines to avoid impersonation attacks

### DIFF
--- a/draft-tschofenig-rats-psa-token.md
+++ b/draft-tschofenig-rats-psa-token.md
@@ -746,6 +746,10 @@ signatures and COSE_Mac0 for MACs, as defined in the COSE specification {{STD96}
 Note, however, that the use of MAC authentication is NOT RECOMMENDED due to the associated
 infrastructure costs for key management and protocol complexities.
 
+A PSA attester MUST NOT expose the PSA attestation API to unauthenticated callers.
+Additionally, a PSA attester MUST NOT send attestation evidence to an unauthenticated challenger.
+Failing to do so may may allow an attacker to interpose between the attester and a verifier, tricking the verifier into believing the attacker is the legitimate attester.
+
 Attestation tokens contain information that may be unique to a device and
 therefore they may allow to single out an individual device for tracking
 purposes.  Deployments that have privacy requirements must take appropriate


### PR DESCRIPTION
Add guidelines to the security consideration section to avoid impersonation attacks via "attestation oracles" and/or unauthenticated challengers.

Fix #116